### PR TITLE
Use downloaders functions from entitysdk

### DIFF
--- a/app/entitycore_helper.py
+++ b/app/entitycore_helper.py
@@ -215,5 +215,5 @@ def run_and_save_calibration_validation(client: Client, memodel_id: str):
 
     validation_dict = run_validations(cell, memodel.name, output_dir="./figures")
 
-    # register_calibration(client, memodel, validation_dict["memodel_properties"])
-    # register_validations(client, memodel, validation_dict)
+    register_calibration(client, memodel, validation_dict["memodel_properties"])
+    register_validations(client, memodel, validation_dict)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pydantic>=2",
     "uvicorn[standard]",
     "bluecellulab>=2.6.51",
-    "entitysdk>=0.4.0"
+    "entitysdk>=0.5.0"
 ]
 requires-python = "==3.12.*"
 readme = "README.md"


### PR DESCRIPTION
The functions to download hoc, morphology and mechanisms have been integrated into entitysdk, so we should get them from there instead of re-implementing them. With this change, we would look for .asc morphology, which I expect to have. In later iteration in entitysdk, we should look for the morphology format that is set in the memodel (to be implemented).

The function to download the whole memodel has also been integrated into entitysdk, but without the threading parallelization, so I think it is ok to keep the one we currently have in me-model-analysis.