### PR TITLE
add flag to mechanism compilation

### DIFF
--- a/app/entitycore_helper.py
+++ b/app/entitycore_helper.py
@@ -171,7 +171,15 @@ def run_and_save_calibration_validation(client: Client, memodel_id: str):
     holding_current, threshold_current = get_holding_and_threshold(memodel.calibration_result)
 
     # compile the mechanisms
-    subprocess.run(["nrnivmodl", str(downloaded_memodel.mechanisms_dir)], check=True)
+    subprocess.run(
+        [
+            "nrnivmodl",
+            "-incflags",
+            "-DDISABLE_REPORTINGLIB",
+            str(downloaded_memodel.mechanisms_dir)
+        ],
+        check=True
+    )
 
     cell = create_bluecellulab_cell(
         downloaded_memodel.hoc_path,


### PR DESCRIPTION
New flags in mechanism compilation. They are for special mechanisms that we might have in models we get from circuits. So we don't need this right now, but it can prevent bugs in the future, once we start using models from circuits.

tagging @darshanmandge who gave me this piece of code